### PR TITLE
FIX: None enum missing

### DIFF
--- a/src/main/java/de/suitepad/linbridge/api/core/AuthenticationState.java
+++ b/src/main/java/de/suitepad/linbridge/api/core/AuthenticationState.java
@@ -6,6 +6,11 @@ import android.os.Parcelable;
 public enum AuthenticationState implements Parcelable {
 
     /**
+     * Initial state for registrations.
+     */
+    None,
+
+    /**
      * Registration is in progress.
      */
     Progress,


### PR DESCRIPTION
The corresponding class `RegistrationState` (in liblinphone), that linbridge-api's `AuthenticationState` tracks, has this enum value `None`. As it was missing in linbridge-api, linbridge was crashing during some edge cases.

ref: #bell-172